### PR TITLE
Delete unused argument which makes it break

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,5 +1,3 @@
-{ bevel-api-server
-}:
 { envname
 }:
 { lib, pkgs, config, ... }:


### PR DESCRIPTION
This makes it work according to the readme, soving this issue:

```
sudo nixos-rebuild switch
error: anonymous function at /nix/store/hs32mqyq84rmm0lsmngwcix8ds49kw1s-source/nix/nixos-module.nix:1:1 called without required argument 'bevel-api-server'

       at /linux-config/configuration.nix:10:5:

            9|   bevel-production = (
           10|     import (
             |     ^
           11|       builtins.fetchGit {
(use '--show-trace' to show detailed location information)
building Nix...
error: anonymous function at /nix/store/hs32mqyq84rmm0lsmngwcix8ds49kw1s-source/nix/nixos-module.nix:1:1 called without required argument 'bevel-api-server'

       at /linux-config/configuration.nix:10:5:

            9|   bevel-production = (
           10|     import (
             |     ^
           11|       builtins.fetchGit {
(use '--show-trace' to show detailed location information)
building the system configuration...
error: anonymous function at /nix/store/hs32mqyq84rmm0lsmngwcix8ds49kw1s-source/nix/nixos-module.nix:1:1 called without required argument 'bevel-api-server'

       at /linux-config/configuration.nix:10:5:

            9|   bevel-production = (
           10|     import (
             |     ^
           11|       builtins.fetchGit {
(use '--show-trace' to show detailed location information)
```