### PR TITLE
Fix: ESC on C-p sets directory to ~

### DIFF
--- a/bevel-harness/bindings.bash
+++ b/bevel-harness/bindings.bash
@@ -1,6 +1,7 @@
 _bevel_cd () {
 	tput rmkx
-  cd $(bevel-select cd)
+  local path="$(bevel-select cd)"
+  [[ -z $path ]] || cd "$path"
   tput smkx
 }
 


### PR DESCRIPTION
I'm not familiar with zsh, so I have only touched the bash. Another
similar commit might be required to fix this in zsh, if it's even a
problem there.
